### PR TITLE
WIP: add Atom and markdown support; add npm conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,21 @@
+#
+# NOTES
+#
+# ------------------------------------------------------------------------------
+# Atom specific
+#
+# if you get the following error:
+# 		whitespace: It is possible that the "whitespace"-package prevents the
+# 		following properties from working reliably: insert_final_newline,
+# 		trim_trailing_whitespace.  You may try reconfiguring or disabling the
+# 		"whitespace"-package to solve regarding issues.
+# then:
+# 	1. open Atom's Command Pallette (e.g. ⌘-⇧-P / cmd-shift-P)
+# 	2. activate "Settings View: View Installed Packages"
+# 	3. filter on "whitespace"
+# 	4. click "Disable" on the whitespace package
+# ------------------------------------------------------------------------------
+
 root = true
 
 [*]
@@ -10,3 +28,8 @@ trim_trailing_whitespace = true
 [{*.yml,*.json}]
 indent_style = space
 indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 3
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Early on in the development of the new platform, we recognized the need for cons
 As an organization, we need to write code for humans and not machines.
 
 ### Coding Conventions and Standards
+* [git](https://github.com/sinet/coding-conventions/blob/master/git.md)
+* [npm](https://github.com/sinet/coding-conventions/blob/master/npm.md)
 * [JavaScript](https://github.com/sinet/coding-conventions/blob/master/javascript.md)
 * [HTML](https://github.com/sinet/coding-conventions/blob/master/html.md)
 * [CSS / Less](https://github.com/sinet/coding-conventions/blob/master/css.md)
@@ -21,14 +23,23 @@ The following three books are great reference for this topic. It is highly recom
 * [Code Complete (2nd Edition)](http://www.amazon.com/Code-Complete-Practical-Handbook-Construction/dp/0735619670)
 
 ## Setup / Configuration
-Using terminal, download the following linting and editor configuration files in your project directory:
+For new or uninitialized projects, use terminal to download the following linting and editor configuration files in your project directory:
 ```bash
 curl -O https://raw.githubusercontent.com/sinet/coding-conventions/master/.editorconfig
 curl -O https://raw.githubusercontent.com/sinet/coding-conventions/master/.eslintrc
 ```
 
-Install these packages for Sublime Text 3
-* [EditorConfig](https://github.com/sindresorhus/editorconfig-sublime)
-* [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter3)
-* [SublimeLinter-eslint](https://github.com/roadhump/SublimeLinter-eslint)
-* [DocBlockr](https://github.com/spadgos/sublime-jsdocs)
+Install the following packages for your editor/IDE of choice:
+
+| Sublime Text 3 |  Atom [0] |
+| :------------: | :--: |
+| [EditorConfig](https://github.com/sindresorhus/editorconfig-sublime) | [EditorConfig](https://atom.io/packages/editorconfig) |
+| [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter3) | [Linter](https://atom.io/packages/linter) |
+| [SublimeLinter-eslint](https://github.com/roadhump/SublimeLinter-eslint) | [linter-eslint](https://atom.io/packages/linter-eslint) |
+| ? | [other linters (e.g. htmlhint, stylelint)](http://atomlinter.github.io/) |
+| [DocBlockr](https://github.com/spadgos/sublime-jsdocs) | [DocBlockr](https://atom.io/packages/docblockr) |
+
+[0] With Atom the following should be able to be installed directly from the command line, via:
+```
+apm install editorconfig linter linter-eslint docblockr
+```

--- a/npm.md
+++ b/npm.md
@@ -1,0 +1,43 @@
+# NPM Versioning standards
+
+## Components
+
+1. After making the component edits:
+   ```
+   bash
+   git add .            # add all the modified files; adjust as appropriate!
+   git commit           # follow git.md#format-of-the-commit-message standards
+   npm run gulp -- bump # Sean: note the space between "-- bump"
+   git push             # push to your forked repo
+   ```
+2. Record the component's package.json version number
+3. Make the pull request
+4. Update PD360-html  
+
+---
+  
+**_EITHER_**  
+
+In [pd360-html](https://github.com/sinet/pd360-html):
+1. update the package.json dependency version to the component's version (from step 2 above)2. update npm-shrinkwrap.json (run `npm-shrinkwrap`)
+3. find component name and change version number in the three different places (version, from, resolved)4. Commit the two files
+5. Run `npm install` (may need to delete npm-shrinkwrap.json and node_modules/@sinet/{component} folder as well  
+   
+**_OR_**  
+
+1. ensure your local "pd360-html" is fully up-to-date
+   ```bash
+   cd path/to/your/local/pd360-html/repo
+   git pull
+   npm install
+   ```
+2. in package.json, manually update the component's dependency version
+3. update shrinkwrap, then prep and push the updates  
+   ```bash
+   npm-shrinkwrap
+   git add .
+   git commit -m "chore: bump _package_name_ to _version_number_"
+   git push
+   ```
+---
+


### PR DESCRIPTION
- Adds corresponding Atom packages to the README.md's Setup/Config section
- Adds a markdown set-up to .editorconfig
- Adds a workaround for an Atom/EditorConfig conflict to .editorconfig
- Adds an npm convention file
  - WIP: This is only an initial attempt to document component versioning
         Will be reviewing with Cebu before merging